### PR TITLE
Default user.type to 'groupchat' when undefined

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -186,7 +186,7 @@ class XmppBot extends Adapter
 
       params =
         to: if user.type in ['direct', 'chat'] then "#{user.room}/#{user.id}" else user.room
-        type: user.type
+        type: user.type or 'groupchat'
         from: @options.username
 
       message = new Xmpp.Element('message', params).

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -292,6 +292,20 @@ describe 'XmppBot', ->
       logger:
         debug: ->
 
+    it 'should use type groupchat if type is undefined', (done) ->
+      user =
+        id: 'mark'
+        room: 'test@example.com'
+
+      bot.client.send = (msg) ->
+        assert.equal msg.parent.attrs.to, 'test@example.com'
+        assert.equal msg.parent.attrs.type, 'groupchat'
+        assert.equal msg.parent.attrs.from, bot.options.username
+        assert.equal msg.getText(), 'testing'
+        done()
+
+      bot.send user, 'testing'
+
     it 'should send messages directly', (done) ->
       user =
         id: 'mark'


### PR DESCRIPTION
Hubot methods like messageRoom don't have any knowledge of XMPP internals and calls #send() with just id and room defined.  This allows those types of requests to default to groupchat.

See here for some background:
https://github.com/github/hubot/pull/208

Totally open to feedback on a better way to go about this as well.

Thanks!
