### PR TITLE
The connection was changed in 2.1.4 and scripts weren't loading without this

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -5,6 +5,8 @@ util    = require 'util'
 
 class XmppBot extends Adapter
   run: ->
+    self = @
+
     options =
       username: process.env.HUBOT_XMPP_USERNAME
       password: process.env.HUBOT_XMPP_PASSWORD
@@ -26,6 +28,8 @@ class XmppBot extends Adapter
     @client.on 'stanza', @.read
 
     @options = options
+
+    self.emit "connected"
 
   error: (error) =>
     @robot.logger.error error.toString()


### PR DESCRIPTION
According to the changelog, in v2.1.4, "Hubot now emits a 'connected' event when he connects to the chosen adapter"

XMPP wasn't doing this and so the scripts weren't getting loaded even though Hubot appeared to be connected properly.
