### PR TITLE
Emit 'connected' event upon successful connection

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -57,6 +57,8 @@ class XmppBot extends Adapter
       @client.send ' '
     , @options.keepaliveInterval
 
+    @emit 'connected'
+
   parseRooms: (items) ->
     rooms = []
     for room in items


### PR DESCRIPTION
Upon successful connection, we should emit a 'connected' event.

This fixes the problem I was having which I described in issue #10.  The scripts weren't being loaded because the 'connected' event was never fired.
