### PR TITLE
FIxing bug with double emit

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -29,8 +29,6 @@ class XmppBot extends Adapter
 
     @options = options
 
-    self.emit "connected"
-
   error: (error) =>
     @robot.logger.error error.toString()
 


### PR DESCRIPTION
Removed double emit of 'connected' when going online.
