### PR TITLE
Fix GTalk XMPP errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -35,8 +35,8 @@ class XmppBot extends Adapter
   online: =>
     @robot.logger.info 'Hubot XMPP client online'
 
-    @client.send new Xmpp.Element('presence', type: 'available' )
-      .c('show').t('chat')
+    @client.send new Xmpp.Element('presence')
+    @robot.logger.info 'Hubot XMPP sent initial presence'
 
     # join each room
     # http://xmpp.org/extensions/xep-0045.html for XMPP chat standard
@@ -149,7 +149,7 @@ class XmppBot extends Adapter
 
         # If the presence is from us, track that.
         # Xmpp sends presence for every person in a room, when join it
-        # Only after we've heard our own presence should we respond to 
+        # Only after we've heard our own presence should we respond to
         # presence messages.
         if from == @robot.name or from == @options.username
           @heardOwnPresence = true
@@ -191,7 +191,6 @@ class XmppBot extends Adapter
       params =
         to: if user.type in ['direct', 'chat'] then "#{user.room}/#{user.id}" else user.room
         type: user.type or 'groupchat'
-        from: @options.username
 
       message = new Xmpp.Element('message', params).
                 c('body').t(str)


### PR DESCRIPTION
Now fully working in a MUC setup on GTalk using the XMPP Hubot adapter and responding to commands nicely. Fixes two fundamental XMPP issues with the original Hubot adapter:
- Only send initial empty presence stanza. Since we do not need to set to non-default value (i.e. not 'available', which is default) then no need to send a non-empty type attribute presence stanza. See 5.2 of [XMPP IEFT working document](http://tools.ietf.org/html/draft-ietf-xmpp-im-01).
- Remove setting of from attribute from message stanza when responding to a message-based command as bot. Otherwise error is sent back by GTalk.

**Note:**
This can be verified by using the `hubot-xmpp2` (version 0.0.5) NPM package in your Hubot dependencies section of your package.json. I can unpublish the NPM package once pull request makes it into a published version of the hubot-xmpp package.
