### PR TITLE
added support for an option to use legacySSL by setting the environment ...

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -12,6 +12,7 @@ class XmppBot extends Adapter
       port: process.env.HUBOT_XMPP_PORT
       rooms:    @parseRooms process.env.HUBOT_XMPP_ROOMS.split(',')
       keepaliveInterval: 30000 # ms interval to send whitespace to xmpp server
+      legacySSL: process.env.HUBOT_XMPP_LEGACYSSL
 
     @robot.logger.info util.inspect(options)
 
@@ -20,6 +21,7 @@ class XmppBot extends Adapter
       password: options.password
       host: options.host
       port: options.port
+      legacySSL: options.legacySSL
 
     @client.on 'error', @.error
     @client.on 'online', @.online


### PR DESCRIPTION
...variable HUBOT_XMPP_LEGACYSSL, which is a boolean value (true/false)

This is supported by node-xmpp: https://github.com/astro/node-xmpp/pull/64. I found this useful in my project, so hopefully someone else will as well.
