### PR TITLE
Fix for node-expat update

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "main": "./src/xmpp.coffee",
   "engine": "node > 0.6.0 < 0.8.0",
   "dependencies": {
-    "node-xmpp": "0.3.2"
+    "node-xmpp": "0.3.2",
+    "node-expat": "1.6.1"
   },
   "devDependencies": {
     "coffee-script": "1.1.3",


### PR DESCRIPTION
Issue is documented here: https://github.com/hipchat/hubot-hipchat/issues/46

I had the same with this module:

```
root@fqdn:/opt/xmppbot# ./bin/hubot -a xmpp
[Fri Oct 26 2012 14:38:18 GMT+0000 (UTC)] ERROR Cannot load adapter xmpp - Error: Cannot find module '../build/Release/node_expat.node'
Error: Cannot find module '../build/Release/node_expat.node'
    at Function._resolveFilename (module.js:337:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:359:17)
    at require (module.js:375:17)
    at Object.<anonymous> (/opt/xmppbot/node_modules/hubot-xmpp/node_modules/node-xmpp/node_modules/node-expat/lib/node-expat.js:4:13)
    at Module._compile (module.js:446:26)
    at Object..js (module.js:464:10)
    at Module.load (module.js:353:32)
    at Function._load (module.js:311:12)
    at Module.require (module.js:359:17)
TypeError: Cannot call method 'on' of null
    at Object.<anonymous> (/opt/xmppbot/node_modules/hubot/bin/hubot:105:19)
    at Object.<anonymous> (/opt/xmppbot/node_modules/hubot/bin/hubot:109:4)
    at Module._compile (module.js:446:26)
    at Object.run (/opt/xmppbot/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:79:25)
    at /opt/xmppbot/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/command.js:175:29
    at /opt/xmppbot/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/command.js:150:18
    at [object Object].<anonymous> (fs.js:123:5)
    at [object Object].emit (events.js:64:17)
    at Object.oncomplete (fs.js:1190:12)
```
- This commit pins hubot-xmpp to the last working version, as they did for hipchat: https://github.com/hipchat/hubot-hipchat/commit/c30790cec2d3587239f8d43f6177df569f972a91
