### PR TITLE
Fix hanging errors

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -233,8 +233,8 @@ class XmppBot extends Adapter
       @robot.logger.debug "Sending to #{envelope.room}: #{msg}"
 
       params =
-        to: if envelope.user.type in ['direct', 'chat'] then "#{envelope.room}/#{envelope.user.id}" else envelope.room
-        type: envelope.user.type or 'groupchat'
+        to: if envelope.user?.type in ['direct', 'chat'] then "#{envelope.room}/#{envelope.user.id}" else envelope.room
+        type: envelope.user?.type or 'groupchat'
 
       if msg.attrs? # Xmpp.Element type
         message = msg.root()


### PR DESCRIPTION
This is really two fixes, I'm sorry for mixing them into one.

The first fix is for some problems I have with my hubot, where it will sometimes "hang" on an error. this happens because the jabber-server restarts every night (Not really sure why, but it does..). Sometimes hubot connects at just the wrong moment and gets ECONNREFUSED, which leaves it just sitting there (the @error handler doesn't do anything). The second error I have seen is when the jabber server shuts down, hubot-xmpp sometimes hangs as well.

Both of the cases might be better handled with reconnection, but I couldn't figure out how to trigger that. If you have pointers, I'd be more than happy to change it :)

The second fix is to allow `robot.messageRoom` to work again. The envelope from that function has no `user` in it, to checking for type fails. I just added the `?` conditional to fall back to the group defaults.
