### PR TITLE
Show placeholder password in info logs. Fixes #1

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -7,7 +7,7 @@ class XmppBot extends Adapter
   run: ->
     options =
       username: process.env.HUBOT_XMPP_USERNAME
-      password: process.env.HUBOT_XMPP_PASSWORD
+      password: '********'
       host: process.env.HUBOT_XMPP_HOST
       port: process.env.HUBOT_XMPP_PORT
       rooms:    @parseRooms process.env.HUBOT_XMPP_ROOMS.split(',')
@@ -16,6 +16,7 @@ class XmppBot extends Adapter
       preferredSaslMechanism: process.env.HUBOT_XMPP_PREFERRED_SASL_MECHANISM
 
     @robot.logger.info util.inspect(options)
+    options.password = process.env.HUBOT_XMPP_PASSWORD
 
     @client = new Xmpp.Client
       jid: options.username


### PR DESCRIPTION
This stops hubot-xmpp from logging out the password associated with its XMPP account.
