### PR TITLE
Upgrade to latest release of node-xmpp

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   "main": "./src/xmpp.coffee",
   "engine": "node > 0.6.0 < 0.8.0",
   "dependencies": {
-    "node-xmpp": "0.3.2",
-    "node-expat": "1.6.1"
+    "node-xmpp": "0.10.0"
   },
   "devDependencies": {
     "coffee-script": "1.1.3",


### PR DESCRIPTION
node-expat was removed from dependencies because node-xmpp has it as a dependency already. I couldn't see it being used for anything else, so I removed it. Seems to work just fine.

Fixes #52. I mentioned having trouble, but that was because I was trying to do it with HEAD, instead of the latest release. Just upgrading to 0.10.0 doesn't seem to have been any trouble at all.
