### PR TITLE
Support for XMPP rosters on connect

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,6 +1,6 @@
 # Hubot XMPP
 
-Connects Hubot to your XMPP network 
+Connects Hubot to your XMPP network
 
 [![Build Status](https://secure.travis-ci.org/markstory/hubot-xmpp.png?branch=master)](http://travis-ci.org/markstory/hubot-xmpp)
 
@@ -32,7 +32,7 @@ Optional:
 
 `HUBOT_XMPP_ROOMS` can be a comma separated list of rooms to join.  If
 your rooms require passwords you should use the `jid:password` syntax.
-Room passwords cannot contain `,`. Room names must be the full jid of the 
+Room passwords cannot contain `,`. Room names must be the full jid of the
 room for example `dev@conference.jabber.example.org`.
 
 ## Installation

--- a/README.mdown
+++ b/README.mdown
@@ -29,6 +29,7 @@ Optional:
   the host to be defined.
 * `HUBOT_XMPP_PREFERRED_SASL_MECHANISM` Used to change the encoding used for SASL.
 * `HUBOT_XMPP_DISALLOW_TLS` Prevent upgrading the connection to a secure one via TLS.
+* `HUBOT_XMPP_CLIENT_ROSTER` Will request and cache the client's roster after connecting
 
 `HUBOT_XMPP_ROOMS` can be a comma separated list of rooms to join.  If
 your rooms require passwords you should use the `jid:password` syntax.

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -45,9 +45,7 @@ class XmppBot extends Adapter
     @connected = false
     @configClient(options)
 
-    # Expose the XMPP client through the robot to allow third-party scripts
-    # to send messages directly
-    @robot.xmppClient = @client
+    # TODO this should just be on robot.adapter.client.roster
     @robot.xmppRoster = []
 
   configClient: (options) ->

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -40,14 +40,10 @@ class XmppBot extends Adapter
       legacySSL: options.legacySSL
       preferredSaslMechanism: options.preferredSaslMechanism
       disallowTLS: options.disallowTLS
-      roster: []
 
     @options = options
     @connected = false
     @configClient(options)
-
-    # TODO this should just be on robot.adapter.client.roster
-    @robot.xmppRoster = []
 
   configClient: (options) ->
     @client.connection.socket.setTimeout 0
@@ -160,11 +156,12 @@ class XmppBot extends Adapter
     # scripts have the option of sending messages to all of the clients contacts
     else if (stanza.attrs.id == 'roster_1' && stanza.children[0]['children'])
       roster_items = stanza.children[0]['children']
-
+      
+      @client.roster = []
+      
       for item in roster_items
         jid = new Xmpp.JID(item.attrs.jid)
         @client.roster.push(jid)
-        @robot.xmppRoster.push(jid)
 
   readMessage: (stanza) =>
     # ignore non-messages

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -40,6 +40,7 @@ class XmppBot extends Adapter
       legacySSL: options.legacySSL
       preferredSaslMechanism: options.preferredSaslMechanism
       disallowTLS: options.disallowTLS
+      roster: []
 
     @options = options
     @connected = false
@@ -162,6 +163,7 @@ class XmppBot extends Adapter
 
       for item in roster_items
         jid = new Xmpp.JID(item.attrs.jid)
+        @client.roster.push(jid)
         @robot.xmppRoster.push(jid)
 
   readMessage: (stanza) =>

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -40,6 +40,7 @@ class XmppBot extends Adapter
       legacySSL: options.legacySSL
       preferredSaslMechanism: options.preferredSaslMechanism
       disallowTLS: options.disallowTLS
+      roster: []
 
     @options = options
     @connected = false
@@ -156,8 +157,6 @@ class XmppBot extends Adapter
     # scripts have the option of sending messages to all of the clients contacts
     else if (stanza.attrs.id == 'roster_1' && stanza.children[0]['children'])
       roster_items = stanza.children[0]['children']
-      
-      @client.roster = []
       
       for item in roster_items
         jid = new Xmpp.JID(item.attrs.jid)

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -158,7 +158,7 @@ class XmppBot extends Adapter
       @client.send pong
     # Keep a record of the client's primarty roster after connecting, so that
     # scripts have the option of sending messages to all of the clients contacts
-    else (stanza.attrs.id == 'roster_1' && stanza.children[0]['children'])
+    else if (stanza.attrs.id == 'roster_1' && stanza.children[0]['children'])
       roster_items = stanza.children[0]['children']
 
       for item in roster_items

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -81,6 +81,11 @@ class XmppBot extends Adapter
     @client.send presence
     @robot.logger.info 'Hubot XMPP sent initial presence'
 
+    # Request client roster
+    @client.send do =>
+      el = new Xmpp.Element('iq', from: @options.username, type: 'get', id: 'roster_1')
+      q = el.c('query', xmlns: 'jabber:iq:roster')
+
     @joinRoom room for room in @options.rooms
 
     @emit if @connected then 'reconnected' else 'connected'

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -40,7 +40,6 @@ class XmppBot extends Adapter
       legacySSL: options.legacySSL
       preferredSaslMechanism: options.preferredSaslMechanism
       disallowTLS: options.disallowTLS
-      roster: []
 
     @options = options
     @connected = false
@@ -158,9 +157,13 @@ class XmppBot extends Adapter
     else if (stanza.attrs.id == 'roster_1' && stanza.children[0]['children'])
       roster_items = stanza.children[0]['children']
       
+      @client.roster = []
+      
       for item in roster_items
         jid = new Xmpp.JID(item.attrs.jid)
         @client.roster.push(jid)
+        
+      @robot.logger.info "roster #{@client.roster}"
 
   readMessage: (stanza) =>
     # ignore non-messages

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -165,7 +165,6 @@ class XmppBot extends Adapter
       roster_items = stanza.children[0]['children']
 
       @client.roster = []
-      
 
       for item in roster_items
         jid = new Xmpp.JID(item.attrs.jid)

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -144,7 +144,7 @@ class XmppBot extends Adapter
         @readIq stanza
 
   readIq: (stanza) =>
-    @robot.logger.info "[received iq] #{stanza}"
+    @robot.logger.debug "[received iq] #{stanza}"
 
     # Some servers use iq pings to make sure the client is still functional.
     # We need to reply or we'll get kicked out of rooms we've joined.
@@ -168,7 +168,7 @@ class XmppBot extends Adapter
         jid = new Xmpp.JID(item.attrs.jid)
         @client.roster.push(jid)
         
-      @robot.logger.info "roster #{@client.roster}"
+      @robot.logger.debug "[setting roster] #{@client.roster}"
 
   readMessage: (stanza) =>
     # ignore non-messages

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -139,7 +139,7 @@ class XmppBot extends Adapter
         @readIq stanza
 
   readIq: (stanza) =>
-    @robot.logger.debug "[received iq] #{stanza}"
+    @robot.logger.info "[received iq] #{stanza}"
 
     # Some servers use iq pings to make sure the client is still functional.
     # We need to reply or we'll get kicked out of rooms we've joined.


### PR DESCRIPTION
I'm trying to eliminate the need for a running a fork of hubot-xmpp just to enable (#41) roster support. The change is pretty minor. The goal here is still to allow for a script like PRX/party-line-hubot@b83852679da18778a5b6d6fcbd6deaee59272fdb to work as a relay/broadcast system over XMPP.

The extra conditional in `readIq` I think it pretty straight forward. I have my doubts about how I exposed `@robot.xmppRoster` and `@robot.xmppClient`. The client may have already been accessible from the robot and I just wasn't sure how, and it may make more sense for the roster to be a property of the client, not the robot. Looking for feedback on either of those points.

If there's a way to accomplish this by extending hubot-xmpp in another library, rather than making this change here directly, I can go that route as well. I just wasn't sure how to intercept the `readIq` block in a good way to do that.

I will add some tests before this gets merged.
