### PR TITLE
Add client to server ping

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -71,7 +71,6 @@ class XmppBot extends Adapter
 
   configClient: (options) ->
     @client.connection.socket.setTimeout 0
-    @client.connection.socket.setKeepAlive true, options.keepaliveInterval
     setInterval(@ping, options.keepaliveInterval)
 
     @client.on 'error', @.error

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -768,10 +768,12 @@ describe 'XmppBot', ->
 
   describe '#configClient', ->
     bot = null
+    clock = null
     options =
       keepaliveInterval: 30000
 
     beforeEach () ->
+      clock = sinon.useFakeTimers()
       bot = Bot.use()
       bot.client =
         connection:
@@ -779,17 +781,21 @@ describe 'XmppBot', ->
         on: ->
         send: ->
 
+    afterEach () ->
+      clock.restore()
+
     it 'should set timeouts', () ->
       bot.client.connection.socket.setTimeout = (val) ->
         assert.equal 0, val, 'Should be 0'
-      bot.client.connection.socket.setKeepAlive = (mode, duration) ->
-        assert.ok mode, 'Should turn keepalive on'
-        assert.equal options.keepaliveInterval, duration
+      bot.ping = sinon.stub()
+
       bot.configClient(options)
+
+      clock.tick(options.keepaliveInterval)
+      assert(bot.ping.called)
 
     it 'should set event listeners', () ->
       bot.client.connection.socket.setTimeout = ->
-      bot.client.connection.socket.setKeepAlive = ->
 
       onCalls = []
       bot.client.on = (event, cb) ->


### PR DESCRIPTION
While there are a couple of lines handling the underlying socket timeout, at least on Openfire servers, the default behavior of this adapter eventually has the hubot instance timeout and then reconnect as a client to the underlying xmpp server every few minutes (depending on the timeout configuration of the server). This fix adds in a ping so that the hubot instance will stay connected indefinitely.
