### PR TITLE
Allow Hubot to send colours over XMPP. Adds (XEP-0071 / XHTML-IM) msg support

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -349,8 +349,16 @@ class XmppBot extends Adapter
         message.attrs.to ?= params.to
         message.attrs.type ?= params.type
       else
-        message = new ltx.Element('message', params).
-                  c('body').t(msg)
+        parsedMsg = try new ltx.parse(msg)
+        bodyMsg   = new ltx.Element('message', params).
+                    c('body').t(msg)
+        message   = if parsedMsg?
+                      bodyMsg.up().
+                      c('html',{xmlns:'http://jabber.org/protocol/xhtml-im'}).
+                      c('body',{xmlns:'http://www.w3.org/1999/xhtml'}).
+                      cnode(parsedMsg)
+                    else
+                      bodyMsg
 
       @client.send message
 

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -618,6 +618,30 @@ describe 'XmppBot', ->
 
       bot.send envelope, el
 
+    it 'should send XHTML messages to the room', (done) ->
+      envelope =
+        user:
+          name: 'mark'
+          type: 'groupchat'
+        room: 'test@example.com'
+
+      bot.client.send = (msg) ->
+        assert.equal msg.root().attrs.to, 'test@example.com'
+        assert.equal msg.root().attrs.type, 'groupchat'
+        assert.equal msg.root().children[0].getText(), "<p><span style='color: #0000ff;'>testing</span></p>"
+        assert.equal msg.parent.parent.name, 'html'
+        assert.equal msg.parent.parent.attrs.xmlns, 'http://jabber.org/protocol/xhtml-im'
+        assert.equal msg.parent.name, 'body'
+        assert.equal msg.parent.attrs.xmlns, 'http://www.w3.org/1999/xhtml'
+        assert.equal msg.name, 'p'
+        assert.equal msg.children[0].name, 'span'
+        assert.equal msg.children[0].attrs.style, 'color: #0000ff;'
+        assert.equal msg.children[0].getText(), 'testing'
+
+        done()
+
+      bot.send envelope, "<p><span style='color: #0000ff;'>testing</span></p>"
+
   describe '#online', () ->
     bot = null
     beforeEach () ->


### PR DESCRIPTION
A Hubot script containing HTML tags can now send colour formatted text (amongst other things).

Example:

`msg.send "<p>#{response.domain} looks <span style='color: #0000ff;'>UP</span> from here.</p>"`

![hubot-colours](https://cloud.githubusercontent.com/assets/153401/5695073/ae9b9c5a-9985-11e4-8c36-6b16854d6f9c.png)
