### PR TITLE
ignore local@domain/2578936351142164331380805 format hubot presence

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -253,7 +253,8 @@ class XmppBot extends Adapter
         )
       when 'available'
         # If the presence is from us, track that.
-        if fromJID.resource == @robot.name
+        if fromJID.resource is @robot.name or
+           stanza.getChild?('nick')?.getText?() is @robot.name
           @heardOwnPresence = true
           return
 
@@ -386,4 +387,3 @@ class XmppBot extends Adapter
 
 exports.use = (robot) ->
   new XmppBot robot
-

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -438,7 +438,7 @@ describe 'XmppBot', ->
       bot.readPresence stanza
 
     it 'should set @heardOwnPresence when the bot presence is received', () ->
-      stanza =
+      stanza1 =
         attrs:
           type: 'available'
           to: 'bot@example.com'
@@ -450,7 +450,20 @@ describe 'XmppBot', ->
                 attrs:
                   jid: 'bot@example.com'
 
-      bot.readPresence stanza
+      stanza2 =
+        attrs:
+          type: 'available'
+          to: 'bot@example.com'
+          from: 'test@example.com/2578936351142164331380805'
+        getChild: ->
+          stub =
+            getText: ->
+              stub = 'bot'
+
+      bot.readPresence stanza1
+      assert.ok bot.heardOwnPresence
+      bot.heardOwnPresence = false
+      bot.readPresence stanza2
       assert.ok bot.heardOwnPresence
 
     # Don't trigger enter messages in a room, until we get our


### PR DESCRIPTION
In some xmpp server(for example http://xmpp.jp), I received  message like this:

```xml
<presence from="local@domain/32155608361421638680552955" 
          to="local@domain/32155608361421638680552955" 
          xmlns:stream="http://etherx.jabber.org/streams">
  <nick xmlns="http://jabber.org/protocol/nick">hubot</nick>
</presence>
```