### PR TITLE
add 0.12 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
     - "0.10"
+    - "0.12"


### PR DESCRIPTION
Since the new version should work with node v0.12  I changed .travis.yml to reflect that.