### PR TITLE
Make commands work without hubot prefix or alias in direct chat

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -29,11 +29,15 @@ Optional:
   the host to be defined.
 * `HUBOT_XMPP_PREFERRED_SASL_MECHANISM` Used to change the encoding used for SASL.
 * `HUBOT_XMPP_DISALLOW_TLS` Prevent upgrading the connection to a secure one via TLS.
+* `HUBOT_XMPP_PM_ADD_PREFIX` Make commands work in PMs to hubot without robot name/alias
 
 `HUBOT_XMPP_ROOMS` can be a comma separated list of rooms to join.  If
 your rooms require passwords you should use the `jid:password` syntax.
 Room passwords cannot contain `,`. Room names must be the full jid of the 
 room for example `dev@conference.jabber.example.org`.
+
+`HUBOT_XMPP_PM_ADD_PREFIX` works by prefixing the private message with hubot name, so a
+side effect is that the bot ignores commands of type `/^command/i`.
 
 ## Installation
 

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -208,6 +208,10 @@ class XmppBot extends Adapter
       room = undefined
       # Also store the private JID so we can use it in the send method
       privateChatJID = from
+      # For private messages, make the commands work even without passing the hubot name or alias
+      if message.slice(0, @robot.name.length).toLowerCase() != @robot.name.toLowerCase() and
+          message.slice(0, process.env.HUBOT_ALIAS?.length).toLowerCase() != process.env.HUBOT_ALIAS?.toLowerCase()
+        message = "#{@robot.name} #{message}"
 
     # note that 'user' isn't a full JID in case of group chat,
     # just the local user part

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -31,6 +31,7 @@ class XmppBot extends Adapter
       legacySSL: process.env.HUBOT_XMPP_LEGACYSSL
       preferredSaslMechanism: process.env.HUBOT_XMPP_PREFERRED_SASL_MECHANISM
       disallowTLS: process.env.HUBOT_XMPP_DISALLOW_TLS
+      pmAddPrefix: process.env.HUBOT_XMPP_PM_ADD_PREFIX
 
     @robot.logger.info util.inspect(options)
     options.password = process.env.HUBOT_XMPP_PASSWORD
@@ -208,8 +209,9 @@ class XmppBot extends Adapter
       room = undefined
       # Also store the private JID so we can use it in the send method
       privateChatJID = from
-      # For private messages, make the commands work even without passing the hubot name or alias
-      if message.slice(0, @robot.name.length).toLowerCase() != @robot.name.toLowerCase() and
+      # For private messages, make the commands work even when they are not prefixed with hubot name or alias
+      if @options.pmAddPrefix and
+          message.slice(0, @robot.name.length).toLowerCase() != @robot.name.toLowerCase() and
           message.slice(0, process.env.HUBOT_ALIAS?.length).toLowerCase() != process.env.HUBOT_ALIAS?.toLowerCase()
         message = "#{@robot.name} #{message}"
 

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -233,13 +233,42 @@ describe 'XmppBot', ->
       stanza.attrs.from = 'test@example.com/bot'
       assert.strictEqual bot.readMessage(stanza), undefined
 
-    it 'should send a message for private message', (done) ->
+    it 'should send a message (with bot name prefix added) for private message', (done) ->
       bot.receive = (message) ->
         assert.equal message.user.type, 'chat'
         assert.equal message.user.name, 'test'
         assert.equal message.user.privateChatJID, 'test@example.com/ernie'
         assert.equal message.user.room, undefined
-        assert.equal message.text, 'message text'
+        assert.equal message.text, 'bot message text'
+        done()
+      bot.readMessage stanza
+
+    it 'should send a message (with bot name prefix) for private message (with bot name prefix)', (done) ->
+      stanza.getChild = () ->
+          body =
+            getText: ->
+              'bot message text'
+      bot.receive = (message) ->
+        assert.equal message.user.type, 'chat'
+        assert.equal message.user.name, 'test'
+        assert.equal message.user.privateChatJID, 'test@example.com/ernie'
+        assert.equal message.user.room, undefined
+        assert.equal message.text, 'bot message text'
+        done()
+      bot.readMessage stanza
+
+    it 'should send a message (with alias prefix) for private message (with alias prefix)', (done) ->
+      process.env.HUBOT_ALIAS = ':'
+      stanza.getChild = () ->
+          body =
+            getText: ->
+              ':message text'
+      bot.receive = (message) ->
+        assert.equal message.user.type, 'chat'
+        assert.equal message.user.name, 'test'
+        assert.equal message.user.privateChatJID, 'test@example.com/ernie'
+        assert.equal message.user.room, undefined
+        assert.equal message.text, ':message text'
         done()
       bot.readMessage stanza
 

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -233,7 +233,18 @@ describe 'XmppBot', ->
       stanza.attrs.from = 'test@example.com/bot'
       assert.strictEqual bot.readMessage(stanza), undefined
 
+    it 'should send a message for private message', (done) ->
+      bot.receive = (message) ->
+        assert.equal message.user.type, 'chat'
+        assert.equal message.user.name, 'test'
+        assert.equal message.user.privateChatJID, 'test@example.com/ernie'
+        assert.equal message.user.room, undefined
+        assert.equal message.text, 'message text'
+        done()
+      bot.readMessage stanza
+
     it 'should send a message (with bot name prefix added) for private message', (done) ->
+      bot.options.pmAddPrefix = true
       bot.receive = (message) ->
         assert.equal message.user.type, 'chat'
         assert.equal message.user.name, 'test'
@@ -248,6 +259,7 @@ describe 'XmppBot', ->
           body =
             getText: ->
               'bot message text'
+      bot.options.pmAddPrefix = true
       bot.receive = (message) ->
         assert.equal message.user.type, 'chat'
         assert.equal message.user.name, 'test'
@@ -263,6 +275,7 @@ describe 'XmppBot', ->
           body =
             getText: ->
               ':message text'
+      bot.options.pmAddPrefix = true
       bot.receive = (message) ->
         assert.equal message.user.type, 'chat'
         assert.equal message.user.name, 'test'


### PR DESCRIPTION
As discussed in https://github.com/markstory/hubot-xmpp/issues/85, this adds the hubot name to private messages to make commands work without having to prefix the messages with hubot name or alias. 

Available as an option and the default behavior is the old one.