### PR TITLE
List users in a room and invite users

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -150,6 +150,18 @@ class XmppBot extends Adapter
         to: "#{room.jid}/#{@robot.name}",
         type: 'unavailable')
 
+  # XMPP invite to a room, directly - http://xmpp.org/extensions/xep-0249.html
+  sendInvite: (room, invitee, reason) ->
+    @client.send do =>
+      @robot.logger.debug "Inviting #{invitee} to #{room.jid}"
+      message = new ltx.Element('message',
+        to : invitee)
+      message.c('x',
+        xmlns : 'jabber:x:conference',
+        jid: room.jid,
+        reason: reason)
+      return message
+
   read: (stanza) =>
     if stanza.attrs.type is 'error'
       @robot.logger.error '[xmpp error]' + stanza

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -337,6 +337,31 @@ describe 'XmppBot', ->
         done()
       bot.topic envelope, 'one', 'two'
 
+  describe '#sendInvite()', ->
+    bot = Bot.use()
+
+    bot.client =
+      stub: 'xmpp client'
+
+    bot.robot =
+      name: 'bot'
+      logger:
+        debug: () ->
+
+    room =
+      jid: 'test@example.com'
+      password: false
+    invitee = 'anup@example.com'
+    reason = 'Inviting to test'
+
+    it 'should call @client.send()', (done) ->
+      bot.client.send = (message) ->
+        assert.equal message.attrs.to, invitee
+        assert.equal message.children[0].attrs.jid, room.jid
+        assert.equal message.children[0].attrs.reason, reason
+        done()
+      bot.sendInvite room, invitee, reason
+
   describe '#error()', ->
     bot = Bot.use()
     bot.robot =

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -181,8 +181,7 @@ describe 'XmppBot', ->
         { attrs: {name: 'anup'} }
       ]
       stanza.children = [ {children: userItems} ]
-      bot.on 'receivedUsersForRoom', (roomJID, usersInRoom) ->
-        assert.equal roomJID, stanza.attrs.from
+      bot.on 'receivedUsersInRoom', (usersInRoom) ->
         assert.deepEqual usersInRoom, (item.attrs.name for item in userItems)
         done()
       bot.readIq stanza
@@ -378,7 +377,15 @@ describe 'XmppBot', ->
         assert.equal message.children[0].name, 'query'
         assert.equal message.children[0].attrs.xmlns, 'http://jabber.org/protocol/disco#items'
         done()
-      bot.getUsersInRoom room
+      bot.getUsersInRoom room, () ->
+
+    it 'should call callback on receiving users', (done) ->
+      users  = ['mark', 'anup']
+      bot.client.send = () ->
+      bot.getUsersInRoom room, (usersInRoom) ->
+        assert.deepEqual usersInRoom, users
+        done()
+      bot.emit 'receivedUsersInRoom', users
 
   describe '#sendInvite()', ->
     bot = Bot.use()

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -174,14 +174,14 @@ describe 'XmppBot', ->
       bot.readIq stanza
 
     it 'should parse room query iqs for users in the room', (done) ->
-      stanza.attrs.id = 'get_users_in_room'
+      stanza.attrs.id = 'get_users_in_room_8139nj32ma'
       stanza.attrs.from = 'test@example.com'
       userItems = [
         { attrs: {name: 'mark'} },
         { attrs: {name: 'anup'} }
       ]
       stanza.children = [ {children: userItems} ]
-      bot.on 'receivedUsersInRoom', (usersInRoom) ->
+      bot.on "completedRequest#{stanza.attrs.id}", (usersInRoom) ->
         assert.deepEqual usersInRoom, (item.attrs.name for item in userItems)
         done()
       bot.readIq stanza
@@ -371,7 +371,7 @@ describe 'XmppBot', ->
     it 'should call @client.send()', (done) ->
       bot.client.send = (message) ->
         assert.equal message.attrs.from, bot.options.username
-        assert.equal message.attrs.id, 'get_users_in_room'
+        assert.equal (message.attrs.id.startsWith 'get_users_in_room'), true
         assert.equal message.attrs.to, room.jid
         assert.equal message.attrs.type, 'get'
         assert.equal message.children[0].name, 'query'
@@ -381,11 +381,13 @@ describe 'XmppBot', ->
 
     it 'should call callback on receiving users', (done) ->
       users  = ['mark', 'anup']
+      requestId = 'get_users_in_room_8139nj32ma'
       bot.client.send = () ->
-      bot.getUsersInRoom room, (usersInRoom) ->
+      callback = (usersInRoom) ->
         assert.deepEqual usersInRoom, users
         done()
-      bot.emit 'receivedUsersInRoom', users
+      bot.getUsersInRoom room, callback, requestId
+      bot.emit "completedRequest#{requestId}", users
 
   describe '#sendInvite()', ->
     bot = Bot.use()


### PR DESCRIPTION
This adds functionality to invite users to rooms, as well as the ability to list the users in a room.

Borrows the invite code from https://github.com/markstory/hubot-xmpp/pull/72 with tests added.

For the list feature, a custom event `receivedUsersForRoom` is emitted after the server response is successfully parsed, and scripts can listen to it to get the list of users. Let me know if other approach makes sense (saving the data in hubot brain?).

The xmpp [specification](http://xmpp.org/extensions/xep-0249.html#impl) leaves it up to the client to discard the invites if the user is already in the room, but clients do not seem to follow it (pidgin and gajim at least). I added the functionality to list the users in a room, so that scripts can use it to check if a user is already in the room, and if they are not, send the invite. Something like:

```
room = {jid: hubotlab@example.com}
usersToInvite = ['anup', 'mark'] 

robot.adapter.getUsersInRoom room

robot.adapter.once 'receivedUsersForRoom', (roomJID, usersInRoom) ->
  for userName in usersToInvite
    if userName not in usersInRoom
      # On clients that support it, users will get a popup with invitation request
      robot.adapter.sendInvite room, "#{userName}@example.com", 'Inviting to test!'
```

Not entirely sure what happens when there are concurrent requests for `getUsersInRoom()`, but right now, we are calling it only once at a time.

The list functionality should also be useful in other cases. There's an open issue regarding this in the hubot repo: https://github.com/github/hubot/issues/742