### PR TITLE
Add id to iq ping stanza

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -8,6 +8,7 @@ util = require 'util'
 class XmppBot extends Adapter
 
   reconnectTryCount: 0
+  currentIqId: 1001
 
   constructor: ( robot ) ->
     @robot = robot
@@ -108,7 +109,7 @@ class XmppBot extends Adapter
     @reconnectTryCount = 0
 
   ping: =>
-    ping = new ltx.Element('iq', type: 'get')
+    ping = new ltx.Element('iq', type: 'get', id: @currentIqId++)
     ping.c('ping', xmlns: 'urn:xmpp:ping')
 
     @robot.logger.debug "[sending ping] #{ping}"


### PR DESCRIPTION
Increments a new id for each ping.  Currently, no id is provided so the response from the server is:
`[Tue Oct 06 2015 12:18:47 GMT-0700 (PDT)] ERROR [xmpp error]<iq type="error" xmlns:stream="http://etherx.jabber.org/streams"><error type="modify"><bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/><text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas" xml:lang="en">Missing 'id'</text></error></iq>`