### PR TITLE
node-xmpp-client 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: node_js
 
-
 matrix:
     fast_finish: true
 
     include:
         - node_js: "0.10"
         - node_js: "0.12"
-        - node_js: "4.0"
-        - node_js: "4.1"
-
-    allow_failures:
         - node_js: "4.0"
         - node_js: "4.1"
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "main": "./src/xmpp",
   "engine": "node > 0.6.0 < 0.13.0",
   "dependencies": {
-    "node-xmpp-client": "1.0.0-alpha20",
-    "ltx": "0.9.0",
-    "node-xmpp-core": "1.0.0-alpha14"
+    "node-xmpp-client": "2.0.2"
   },
   "devDependencies": {
     "coffee-script": "1.1.3",

--- a/test/adapter-test.coffee
+++ b/test/adapter-test.coffee
@@ -1,6 +1,6 @@
 Bot = require '../src/xmpp'
 XmppClient = require 'node-xmpp-client'
-ltx = require 'ltx'
+ltx = XmppClient.ltx
 
 {Adapter,Robot,EnterMessage,LeaveMessage,TextMessage} = require 'hubot'
 


### PR DESCRIPTION
node-xmpp-client 2 is io 2 / node 4 compatible as it doesn't use native bindings anymore