### PR TITLE
Add v4.2 Node LTS version to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ matrix:
         - node_js: "0.12"
         - node_js: "4.0"
         - node_js: "4.1"
+        - node_js: "4.2"
 
 sudo: false


### PR DESCRIPTION
Once again there's a new node version.  I just added the latest version to travis.