### PR TITLE
Optional behavior to ignore message history if required

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "node-xmpp-client": "3.0.0"
+    "node-xmpp-client": "3.0.0",
+    "uuid": "2.0.2"
   },
   "devDependencies": {
     "coffee-script": "1.1.3",

--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -1,11 +1,14 @@
 {Adapter,Robot,TextMessage,EnterMessage,LeaveMessage} = require 'hubot'
 {JID, Stanza, Client, parse, Element} = require 'node-xmpp-client'
+uuid = require 'uuid'
 util = require 'util'
 
 class XmppBot extends Adapter
 
   reconnectTryCount: 0
   currentIqId: 1001
+  joining: []
+  joined: []
 
   constructor: ( robot ) ->
     @robot = robot
@@ -143,6 +146,16 @@ class XmppBot extends Adapter
         x.c('password').t(room.password)
       return x
 
+    # send a guid message and ignore any responses until that's been received
+    uuid = uuid.v4()
+    params = {
+      to: room.jid
+      type: 'groupchat'
+    }
+    @robot.logger.info "Joining #{room.jid} with #{uuid}"
+    @joining[uuid] = room.jid
+    @client.send new Stanza('message', params).c('body').t(uuid)
+
   # XMPP Leaving a room - http://xmpp.org/extensions/xep-0045.html#exit
   leaveRoom: (room) ->
     # messageFromRoom check for joined rooms so remvove it from the list
@@ -244,6 +257,11 @@ class XmppBot extends Adapter
     from = stanza.attrs.from
     message = body.getText()
 
+    # check if this is a join guid and if so start accepting messages
+    if message of @joining
+      @robot.logger.info "Now accepting messages from #{@joining[message]}"
+      @joined.push @joining[message]
+
     if stanza.attrs.type == 'groupchat'
       # Everything before the / is the room name in groupchat JID
       [room, user] = from.split '/'
@@ -279,6 +297,9 @@ class XmppBot extends Adapter
     user.type = stanza.attrs.type
     user.room = room
     user.privateChatJID = privateChatJID if privateChatJID
+
+    # only process persistent chant messages if we have matched a join
+    return if stanza.attrs.type == 'groupchat' and user.room not in @joined
 
     @robot.logger.debug "Received message: #{message} in room: #{user.room}, from: #{user.name}. Private chat JID is #{user.privateChatJID}"
 


### PR DESCRIPTION
Some xmpp implementations seem to [ignore the the clients request to suppress message history](https://xmpp.org/extensions/xep-0045.html#enter-managehistory)

> Note: It is known that not all service implementations support MUC history management, so in practice a client might not be able to depend on receiving only the history that it has requested.

Introducing a new HUBOT_XMPP_UUID_ON_JOIN variable which enables the following behaviour
* on joining a room the bot will send a uuid
* any messages are ignored until the uuid is heard

See https://github.com/markstory/hubot-xmpp/issues/104