### PR TITLE
with the newer node-xmpp, preferredSaslMechanism is renamed to preferred

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -76,7 +76,7 @@ class XmppBot extends Adapter
       host: options.host
       port: options.port
       legacySSL: options.legacySSL
-      preferredSaslMechanism: options.preferredSaslMechanism
+      preferred: options.preferredSaslMechanism
       disallowTLS: options.disallowTLS
     @configClient(options)
 


### PR DESCRIPTION
https://github.com/node-xmpp/node-xmpp/blob/master/packages/node-xmpp-client/lib/Client.js#L169