### PR TITLE
Fix exception on room presence stanza

### DIFF
--- a/src/xmpp.coffee
+++ b/src/xmpp.coffee
@@ -346,6 +346,11 @@ class XmppBot extends Adapter
         room = fromJID.bare().toString()
         return if not @messageFromRoom room
 
+        # Some servers send presence for the room itself, which needs to be
+        # ignored
+        if room is fromJID.toString()
+          return
+
         # Try to resolve the private JID
         privateChatJID = @resolvePrivateJID(stanza)
 


### PR DESCRIPTION
Our XMPP server sends presence stanzas for the room itself, in addition to normal user presence ones. Which resulted in an exception, when the code tried to access the non-existent "resource" part of the JID, which would usually contain the username/nickname.